### PR TITLE
Update drawer focus trap implementation

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -12,6 +12,9 @@ $cardPad_Desktop: 8.5rem;
 }
 
 @mixin pageTitle {
+    background: linear-gradient(145deg, var(--blueDark2) 20%, var(--blueDark) 85%);
+    background-clip: text;
+    color: transparent;
     font-size: 3.6rem;
     font-weight: 700;
     letter-spacing: -.15rem;

--- a/src/app/components/j-murky-hawk-drawer/j-murky-hawk-drawer.component.html
+++ b/src/app/components/j-murky-hawk-drawer/j-murky-hawk-drawer.component.html
@@ -65,7 +65,6 @@
     <div *ngIf="drawerShow()"
         id="jmDrawerContent" 
         class="jmDrawer" 
-        (click)="jmDrawerClickFocus()"
         aria-labelledby="jmDrawerButton"
         [ngStyle]="{width: drawerWidth}"
         [@drawerOpenClose]="{


### PR DESCRIPTION
Update drawer focus trap implementation by removing hostListener and moving to rxjs based methodology. This will allow unfocusing the toggle button, as well as accounting for user tabbing into the app when drawer is open from the browser itself - need to prevent focus from going into the page when the drawer is opened in this case.